### PR TITLE
ArduCopter arm/disarm support in mavutil

### DIFF
--- a/pymavlink/mavutil.py
+++ b/pymavlink/mavutil.py
@@ -440,6 +440,38 @@ class mavfile(object):
             self.recv_match(type='GPS_RAW', blocking=True,
                             condition='GPS_RAW.fix_type==2 and GPS_RAW.lat != 0 and GPS_RAW.alt != 0')
 
+    def arducopter_arm(self):
+        '''arm motors (arducopter only)'''
+        if self.mavlink10():
+            self.mav.command_long_send(
+                self.target_system,  # target_system
+                mavlink.MAV_COMP_ID_SYSTEM_CONTROL, # target_component
+                mavlink.MAV_CMD_COMPONENT_ARM_DISARM, # command
+                0, # confirmation
+                1, # param1 (1 to indicate arm)
+                0, # param2 (all other params meaningless)
+                0, # param3
+                0, # param4
+                0, # param5
+                0, # param6
+                0) # param7
+
+    def arducopter_disarm(self):
+        '''calibrate pressure'''
+        if self.mavlink10():
+            self.mav.command_long_send(
+                self.target_system,  # target_system
+                mavlink.MAV_COMP_ID_SYSTEM_CONTROL, # target_component
+                mavlink.MAV_CMD_COMPONENT_ARM_DISARM, # command
+                0, # confirmation
+                0, # param1 (0 to indicate disarm)
+                0, # param2 (all other params meaningless)
+                0, # param3
+                0, # param4
+                0, # param5
+                0, # param6
+                0) # param7
+
     def location(self):
         '''return current location'''
         self.wait_gps_fix()


### PR DESCRIPTION
The ArduCopter trunk now supports arming and disarming motors via MAVLink message.  These changes to add the methods `arducopter_arm(self)` and `arducopter_disarm(self)` to the `mavfile` class in mavutil.py, which sends an appropriate `COMMAND_LONG` message.

---

For reference, commit message to the ardupilot-mega repository for implementing the arm and disarm commands in ArduCopter/GCS_Mavlink.pde:

commit 83c7f035b551a351760ff26dbd5a0ec4fc92a424
Author: Pat Hickey pat@moreproductive.org
Date:   Tue Oct 9 18:48:05 2012 -0700

```
ArduCopter GCS_MAVLink: COMMAND_LONG for arm/disarm motors

Date: Wed, 26 Sep 2012 15:56:43 -0700
Subject: ArduCopter arm/disarm command consensus
From: Pat Hickey <pat@moreproductive.org>
To: Michael Oborne <michael@oborne.me>
Cc: "Craig J. Elder" <craig@3drobotics.com>, arducopter
<arducopter@googlegroups.com>,
    mavelous <mavelous@googlegroups.com>

    Michael,

    Per our discussion today,

    In a MAVLINK_MSG_ID_COMMAND_LONG
    A MAV_CMD of type MAV_CMD_COMPONENT_ARM_DISARM
    with component id MAV_COMP_ID_SYSTEM_CONTROL = 250,
    uses param index 1 to specify an arm/disarm motors event: 1 to arm,
    0 to disarm

    Thanks for working this out with me. Sorry to get it so completely
    wrong the first time around!

    Best
    Pat
```
